### PR TITLE
Fix: define method name in packages, that contains invokes from C/Java

### DIFF
--- a/p_stack.9.sql
+++ b/p_stack.9.sql
@@ -550,7 +550,7 @@ begin
                                                     else '-TYP'
                                                   end || tToken;
               end if;
-              if tLookForDefinition = 1 and tPrevToken in ( 'IS', 'AS' ) and tToken not in ( 'NOT', 'NULL' ) then
+              if tLookForDefinition = 1 and tPrevToken in ( 'IS', 'AS' ) and tToken not in ( 'NOT', 'NULL', 'LANGUAGE' ) then
                 tLookForDefinition := 0;
               end if;
             end if;

--- a/p_stack.sql
+++ b/p_stack.sql
@@ -581,7 +581,7 @@ begin
                                                     else '-TYP'
                                                   end || tToken;
               end if;
-              if tLookForDefinition = 1 and tPrevToken in ( 'IS', 'AS' ) and tToken not in ( 'NOT', 'NULL' ) then
+              if tLookForDefinition = 1 and tPrevToken in ( 'IS', 'AS' ) and tToken not in ( 'NOT', 'NULL', 'LANGUAGE' ) then
                 tLookForDefinition := 0;
               end if;
             end if;


### PR DESCRIPTION
fix for issue #2 
I've test p_stack only, not p_stack.9 but this part of parsing is the same.