### PR TITLE
FIX: p_stack.getCallStack - value error on tIdentifierName when alias over 30 bytes

### DIFF
--- a/p_stack.sql
+++ b/p_stack.sql
@@ -252,8 +252,8 @@ function getCallStack( tFormatCallStack in varchar2, tDepth in number default nu
   len pls_integer;
   tCommented pls_integer;
   tIdentifier pls_integer;
-  tIdentifierName varchar2( 30 );
-  tIdentifiers dbms_sql.varchar2_table;
+  tIdentifierName varchar2( 32767 );
+  tIdentifiers dbms_sql.varchar2a;
   tMaxIdentifier pls_integer;
   tQuoteDelimiter char;
   tString pls_integer;


### PR DESCRIPTION
In Oracle, there are functions (e.g. `XMLFOREST`) ​​whose arguments have a specific syntax - in particular, they can have aliases. These aliases are recognized by `p_stack.getCallStack` as identifier names. The main problem is that the length limit for them - depending on the version and database settings - is 4000 (`MAX_STRING_SIZE = STANDARD`) or 32767 (`MAX_STRING_SIZE = EXTENDED`).

The effect of the above is the possibility of an `ORA-06502 exception` (`Value Error`) during string concatenation and assignment to the `tIdentifierName` variable. 

The simplest way to fix this was to simply increase the maximum length for this variable. It is worth emphasizing that since Oracle 12.2, the maximum length of an identifier is 128 bytes.

I have placed a sample code presenting the problem with the appropriate test at the end of `p_stack_tests.sql`.

There is also a small fix in tests  syntax - `/` after procedure drop is unnecessary. In SQL*Plus this causes the command to be re-executed and results in an error that the procedure does not exist.